### PR TITLE
Adds blank fallbacks for environment variables

### DIFF
--- a/scripts/actions.js
+++ b/scripts/actions.js
@@ -12,18 +12,18 @@ require('dotenv').config()
 
 var paths = require('../config/paths');
 
-const NAME = process.env.EXTENSION_NAME
-const PASSWORD = process.env.EXTENSION_CERTIFICATE_PASSWORD
-const CERTIFICATE = process.env.EXTENSION_CERTIFICATE
-const BUNDLE_ID = process.env.EXTENSION_BUNDLE_ID
-const BUNDLE_VERSION = process.env.EXTENSION_BUNDLE_VERSION
-const CEP_VERSION = process.env.EXTENSION_CEP_VERSION
-const PANEL_WIDTH = process.env.EXTENSION_PANEL_WIDTH
-const PANEL_HEIGHT = process.env.EXTENSION_PANEL_HEIGHT
-const CEF_PARAMS = process.env.EXTENSION_CEF_PARAMS
-const AUTO_OPEN_REMOTE_DEBUGGER = process.env.EXTENSION_AUTO_OPEN_REMOTE_DEBUGGER
-const ENABLE_PLAYERDEBUGMODE = process.env.EXTENSION_ENABLE_PLAYERDEBUGMODE
-const TAIL_LOGS = process.env.EXTENSION_TAIL_LOGS
+const NAME = process.env.EXTENSION_NAME || ''
+const PASSWORD = process.env.EXTENSION_CERTIFICATE_PASSWORD || ''
+const CERTIFICATE = process.env.EXTENSION_CERTIFICATE || ''
+const BUNDLE_ID = process.env.EXTENSION_BUNDLE_ID || ''
+const BUNDLE_VERSION = process.env.EXTENSION_BUNDLE_VERSION || ''
+const CEP_VERSION = process.env.EXTENSION_CEP_VERSION || ''
+const PANEL_WIDTH = process.env.EXTENSION_PANEL_WIDTH || ''
+const PANEL_HEIGHT = process.env.EXTENSION_PANEL_HEIGHT || ''
+const CEF_PARAMS = process.env.EXTENSION_CEF_PARAMS || ''
+const AUTO_OPEN_REMOTE_DEBUGGER = process.env.EXTENSION_AUTO_OPEN_REMOTE_DEBUGGER || ''
+const ENABLE_PLAYERDEBUGMODE = process.env.EXTENSION_ENABLE_PLAYERDEBUGMODE || ''
+const TAIL_LOGS = process.env.EXTENSION_TAIL_LOGS || ''
 const APP_IDS = process.env.EXTENSION_APP_IDS || 'AEFT'
 
 const package = require('../package.json')


### PR DESCRIPTION
Hey, this probably isn’t the right way to solve this issue, so feel free to treat this as more of an issue than a PR. Right now the [sample](https://github.com/fusepilot/create-cep-extension-example) won’t run without the `.env` file from this project. I was getting an error like:

```sh
path.js:7
    throw new TypeError('Path must be a string. Received ' + inspect(path));
    ^

TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.join (path.js:1211:7)
    at symlinkExtension (/Users/Kenneth/Sites/kennethormandy/create-cep-extension/scripts/actions.js:148:25)
    at Compiler.<anonymous> (/Users/Kenneth/Sites/kennethormandy/create-cep-extension/scripts/start.js:110:5)
```

…and this is a quick fix for that.