### PR TITLE
Restores file loader from Create React App

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -132,7 +132,7 @@ module.exports = {
         loader: 'url-loader',
         options: {
           // limit: 10000,
-          name: 'media/[name].[ext]'
+          name: 'static/media/[name].[hash:8].[ext]',
         }
       },
       // Process JS with Babel.

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -105,6 +105,22 @@ module.exports = {
       // "file" loader makes sure those assets get served by WebpackDevServer.
       // When you `import` an asset, you get its (virtual) filename.
       // In production, they would get copied to the `build` folder.
+      {
+        exclude: [
+          /\.html$/,
+          /\.(js|jsx)$/,
+          /\.css$/,
+          /\.json$/,
+          /\.bmp$/,
+          /\.gif$/,
+          /\.jpe?g$/,
+          /\.png$/,
+        ],
+        loader: 'file-loader',
+        options: {
+          name: 'static/media/[name].[hash:8].[ext]',
+        },
+      },
       // "url" loader works like "file" loader except that it embeds assets
       // smaller than specified limit in bytes as data URLs to avoid requests.
       // A missing `test` is equivalent to a match.
@@ -149,14 +165,6 @@ module.exports = {
         test: /\.css$/,
         loader: 'style-loader!css-loader?importLoaders=1!postcss-loader'
       },
-      // "file" loader for svg
-      {
-        test: /\.svg$/,
-        loader: 'file-loader',
-        options: {
-          name: 'media/[name].[hash].[ext]'
-        }
-      }
     ]
   },
   plugins: [
@@ -222,4 +230,3 @@ module.exports = {
     tls: 'empty'
   }
 };
-

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -133,7 +133,7 @@ module.exports = {
         loader: 'url-loader',
         query: {
           // limit: 10000,
-          name: 'media/[name].[ext]'
+          name: 'static/media/[name].[hash:8].[ext]',
         }
       },
       {

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -107,6 +107,22 @@ module.exports = {
       //
       // "file" loader makes sure those assets end up in the `build` folder.
       // When you `import` an asset, you get its filename.
+      {
+        exclude: [
+          /\.html$/,
+          /\.(js|jsx)$/,
+          /\.css$/,
+          /\.json$/,
+          /\.bmp$/,
+          /\.gif$/,
+          /\.jpe?g$/,
+          /\.png$/,
+        ],
+        loader: 'file-loader',
+        options: {
+          name: 'static/media/[name].[hash:8].[ext]',
+        },
+      },
       // "url" loader works just like "file" loader but it also embeds
       // assets smaller than specified size as data URLs to avoid requests.
       {
@@ -153,14 +169,6 @@ module.exports = {
           loader: 'css-loader?importLoaders=1!postcss-loader'
         })
       },
-      // "file" loader for svg
-      {
-        test: /\.svg$/,
-        loader: 'file-loader',
-        options: {
-          name: 'media/[name].[hash].[ext]'
-        }
-      }
     ]
   },
   plugins: [


### PR DESCRIPTION
This restores the `file-loader` from the [current master](https://github.com/facebookincubator/create-react-app/blob/ccb5f84dc6455024c486a80f0060c9802b5cb5d1/packages/react-scripts/config/webpack.config.dev.js#L139-L154) of Create React App, which restores support for loading in additional files into the build directory. It also removes the need for the SVG-specific loader.

Note that this also means the path is `static/media/[name].[hash:8].[ext]` where before it would have just been `media/[name].[hash:8].[ext]`, so if you were to run the example app the file would now be in `static/media/logo.whatever123.svg` instead of `media/logo.whatever123.svg`, I’m not sure if that was a change in Create React App or if you intentionally had a different directory for a reason I’m not familiar with. I left the `url-loader` config in place since I wasn’t entirely sure about that, but it would probably make sense to keep them the same, so I can make that change based on your advice.