### PR TITLE
Currently only supports AEFT, use app ID in manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Then finally add a ````.env```` file with your extension's configuration.
 ````bash
 EXTENSION_NAME="My Extension"
 EXTENSION_APP_IDS="AEFT"
+EXTENSION_APP_VERSIONS="13.0"
 EXTENSION_BUNDLE_ID="com.mycompany.myextension"
 
 EXTENSION_CERTIFICATE_COUNTRY="US"

--- a/scripts/actions.js
+++ b/scripts/actions.js
@@ -25,6 +25,8 @@ const AUTO_OPEN_REMOTE_DEBUGGER = process.env.EXTENSION_AUTO_OPEN_REMOTE_DEBUGGE
 const ENABLE_PLAYERDEBUGMODE = process.env.EXTENSION_ENABLE_PLAYERDEBUGMODE || ''
 const TAIL_LOGS = process.env.EXTENSION_TAIL_LOGS || ''
 const APP_IDS = process.env.EXTENSION_APP_IDS || 'AEFT'
+const APP_VERSIONS = process.env.EXTENSION_APP_VERSIONS || '[13.0,15.9]'
+
 
 const package = require('../package.json')
 const VERSION = package.version.split('-')[0] // because ae doesnt load extensions that arent in the exact format '1.0.0'
@@ -126,6 +128,8 @@ function writeExtensionTemplates(env, {port}={}) {
     bundleName: NAME,
     bundleId: BUNDLE_ID,
     bundleVersion: VERSION,
+    bundleAppIds: APP_IDS,
+    bundleAppVersions: APP_VERSIONS
   })
   fs.writeFileSync(path.join(paths.appBuild, 'CSXS/manifest.xml'), manifestContents)
 

--- a/templates/manifest.js
+++ b/templates/manifest.js
@@ -10,9 +10,6 @@ module.exports = function ({
   cefParams = ['--allow-file-access-from-files', '--allow-file-access', '--enable-nodejs', '--mixed-context']
 }) {
   var commandLineParams = cefParams.map(cefParam => `<Parameter>${cefParam}</Parameter>`)
-  var appIds = Array.isArray(bundleAppIds) ? bundleAppIds : [bundleAppIds]
-  var appVersions = Array.isArray(bundleAppVersions) ? bundleAppVersions : [bundleAppVersions]
-  var hosts = appIds.map((host, i) => `<Host Name="${host}" Version="${appVersions[i]}" />`)
 
   return `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <ExtensionManifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ExtensionBundleId="${bundleId}" ExtensionBundleName="${bundleName}" ExtensionBundleVersion="${bundleVersion}" Version="${cepVersion}">
@@ -21,7 +18,7 @@ module.exports = function ({
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>
-      ${hosts.join('\n      ')}
+      <Host Name="${appId}" Version="${appVersion}" />
     </HostList>
     <LocaleList>
       <Locale Code="All"/>

--- a/templates/manifest.js
+++ b/templates/manifest.js
@@ -1,6 +1,8 @@
 module.exports = function ({
   bundleName = 'My Extension',
   bundleId = 'com.test.test.extension',
+  bundleAppIds = 'AEFT',
+  bundleAppVersions = '[13.0,15.9]',
   bundleVersion = '1.0.0',
   cepVersion = '6.0',
   width = '500',
@@ -8,6 +10,10 @@ module.exports = function ({
   cefParams = ['--allow-file-access-from-files', '--allow-file-access', '--enable-nodejs', '--mixed-context']
 }) {
   var commandLineParams = cefParams.map(cefParam => `<Parameter>${cefParam}</Parameter>`)
+  var appIds = Array.isArray(bundleAppIds) ? bundleAppIds : [bundleAppIds]
+  var appVersions = Array.isArray(bundleAppVersions) ? bundleAppVersions : [bundleAppVersions]
+  var hosts = appIds.map((host, i) => `<Host Name="${host}" Version="${appVersions[i]}" />`)
+
   return `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <ExtensionManifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ExtensionBundleId="${bundleId}" ExtensionBundleName="${bundleName}" ExtensionBundleVersion="${bundleVersion}" Version="${cepVersion}">
   <ExtensionList>
@@ -15,7 +21,7 @@ module.exports = function ({
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>
-      <Host Name="AEFT" Version="[13.0,15.9]" />
+      ${hosts.join('\n      ')}
     </HostList>
     <LocaleList>
       <Locale Code="All"/>

--- a/templates/manifest.js
+++ b/templates/manifest.js
@@ -18,7 +18,7 @@ module.exports = function ({
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>
-      <Host Name="${appId}" Version="${appVersion}" />
+      <Host Name="${bundleAppIds}" Version="${bundleAppVersions}" />
     </HostList>
     <LocaleList>
       <Locale Code="All"/>


### PR DESCRIPTION
### Expected

I should be able to supply the `EXTENSION_APP_IDS` environment variable to another application (ex. `IDSN`) and set a specific version, and have Create CEP Extension build the manifest so it runs in that application.

### Actual

I can supply the `EXTENSION_APP_IDS`, but the manifest always is for `AEFT`. There’s no way to pass along a specific version of the application.

***

This pull request replaces the hard-coded `AEFT` with the environment variable, and adds a `EXTENSION_APP_VERSIONS` environment variable for the version. You can still pass multiple version numbers for one app (ex. `"[13.0,15.9]"` which I left as the default), but you still can’t add multiple applications.

It didn’t seem like environment variables would work as well to configure more than one app, what do you think? I think the `package.json` could be an alternate place to hold the config, maybe other than the stuff you wouldn’t necessarily want to commit like the password.

Maybe in [engines](https://docs.npmjs.com/files/package.json#engines)?

```json
"engines": {
  "node": "6.9.x",
  "npm": "3.x",
  "AEFT": ["13.0", "15.9"],
  "IDSN": "11.0"
}
```

…or it could be all within its own Create CEP Extension config object?