### PR TITLE
Improve target host configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,7 @@ Then finally add a ````.env```` file with your extension's configuration.
 
 ````bash
 EXTENSION_NAME="My Extension"
-EXTENSION_APP_IDS="AEFT"
-EXTENSION_APP_VERSIONS="13.0"
 EXTENSION_BUNDLE_ID="com.mycompany.myextension"
-
 EXTENSION_CERTIFICATE_COUNTRY="US"
 EXTENSION_CERTIFICATE_PROVINCE="CA"
 EXTENSION_CERTIFICATE_ORG="MyCompany"
@@ -34,7 +31,15 @@ EXTENSION_CERTIFICATE_PASSWORD="mypassword"
 EXTENSION_CERTIFICATE="certificate.p12"
 ````
 
+### Target Hosts
 
+By default, the extension will target all known Adobe hosts. To target specific hosts, add a `EXTENSION_HOST_IDS` variable to your `.env` with a comma delimited list of the host id's you want to target.
+
+For example, to target just In Design and After Effects, you would add this to your `.env` file:
+
+````bash
+EXTENSION_HOST_IDS="IDSN, AEFT"
+````
 
 ## Usage
 

--- a/scripts/actions.js
+++ b/scripts/actions.js
@@ -24,8 +24,8 @@ const CEF_PARAMS = process.env.EXTENSION_CEF_PARAMS || ''
 const AUTO_OPEN_REMOTE_DEBUGGER = process.env.EXTENSION_AUTO_OPEN_REMOTE_DEBUGGER || ''
 const ENABLE_PLAYERDEBUGMODE = process.env.EXTENSION_ENABLE_PLAYERDEBUGMODE || ''
 const TAIL_LOGS = process.env.EXTENSION_TAIL_LOGS || ''
-const APP_IDS = process.env.EXTENSION_APP_IDS || 'AEFT'
-const APP_VERSIONS = process.env.EXTENSION_APP_VERSIONS || '[13.0,15.9]'
+const HOST_IDS = process.env.EXTENSION_HOST_IDS
+const HOST_VERSIONS = process.env.EXTENSION_HOST_VERSIONS
 
 
 const package = require('../package.json')
@@ -119,7 +119,7 @@ function writeExtensionTemplates(env, {port}={}) {
 
   if (env === 'dev') {
     // write .debug file
-    const debugContents = debugTemplate(BUNDLE_ID, APP_IDS.split(','))
+    const debugContents = debugTemplate(BUNDLE_ID, HOST_IDS)
     fs.writeFileSync(path.join(paths.appBuild, '.debug'), debugContents)
   }
 
@@ -128,8 +128,8 @@ function writeExtensionTemplates(env, {port}={}) {
     bundleName: NAME,
     bundleId: BUNDLE_ID,
     bundleVersion: VERSION,
-    bundleAppIds: APP_IDS,
-    bundleAppVersions: APP_VERSIONS
+    bundleHostIds: HOST_IDS,
+    bundleHostVersions: HOST_VERSIONS
   })
   fs.writeFileSync(path.join(paths.appBuild, 'CSXS/manifest.xml'), manifestContents)
 

--- a/templates/.debug.js
+++ b/templates/.debug.js
@@ -1,12 +1,12 @@
 module.exports = function (
 	bundleId = 'com.test.test.extension',
-	appIds = ['AEFT']
+	hostNames = 'PHXS, PHSP, IDSN, AICY, ILST, PPRO, AEFT, PRLD, FLPR, DRWV'
 ) {
 	return `<?xml version="1.0" encoding="UTF-8"?>
 <ExtensionList>
   <Extension Id="${bundleId}">
   <HostList>
-    ${appIds.map((appId, i) => `<Host Name="${appId}" Port="${'' + (3000 + i + 1)}" />`).join('\n    ')}
+    ${hostNames.split(',').map((hostName, i) => `<Host Name="${hostName.trim()}" Port="${'' + (3000 + i + 1)}" />`).join('\n    ')}
   </HostList>
   </Extension>
 </ExtensionList>`

--- a/templates/manifest.js
+++ b/templates/manifest.js
@@ -1,8 +1,8 @@
 module.exports = function ({
   bundleName = 'My Extension',
   bundleId = 'com.test.test.extension',
-  bundleAppIds = 'AEFT',
-  bundleAppVersions = '[13.0,15.9]',
+  bundleHostIds = 'PHXS, PHSP, IDSN, AICY, ILST, PPRO, AEFT, PRLD, FLPR, DRWV',
+  bundleHostVersions = '[0.0,99.9]',
   bundleVersion = '1.0.0',
   cepVersion = '6.0',
   width = '500',
@@ -10,6 +10,7 @@ module.exports = function ({
   cefParams = ['--allow-file-access-from-files', '--allow-file-access', '--enable-nodejs', '--mixed-context']
 }) {
   var commandLineParams = cefParams.map(cefParam => `<Parameter>${cefParam}</Parameter>`)
+  var hosts = bundleHostIds.split(',').map(bundleHostId => `<Host Name="${bundleHostId.trim()}" Version="${bundleHostVersions}" />`)
 
   return `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <ExtensionManifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ExtensionBundleId="${bundleId}" ExtensionBundleName="${bundleName}" ExtensionBundleVersion="${bundleVersion}" Version="${cepVersion}">
@@ -18,7 +19,7 @@ module.exports = function ({
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>
-      <Host Name="${bundleAppIds}" Version="${bundleAppVersions}" />
+      ${hosts.join('\n      ')}
     </HostList>
     <LocaleList>
       <Locale Code="All"/>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1452,10 +1452,6 @@ cosmiconfig@^2.1.0, cosmiconfig@^2.1.1:
     parse-json "^2.2.0"
     require-from-string "^1.1.0"
 
-create-cep-extension@^1.0.0-beta.0:
-  version "1.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/create-cep-extension/-/create-cep-extension-1.0.0-beta.0.tgz#bc6ec3e64ddaf5e64f771b55f2381db4476526b2"
-
 create-ecdh@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.0.tgz#888c723596cdf7612f6498233eebd7a35301737d"
@@ -3525,7 +3521,7 @@ lodash.uniq@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.1:
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
This simplifies the host configuration. And in spirit with CRA, targets all known Adobe hosts by default with the version set to [0.0,99.9]. So now, instead of users having to find the right host id and version for whichever app they're targeting, it will just work.