### PR TITLE
Add support for windows development machine

### DIFF
--- a/packages/create-cep-extension-scripts/scripts/archive.js
+++ b/packages/create-cep-extension-scripts/scripts/archive.js
@@ -107,7 +107,9 @@ function certificate() {
 
 function fixZXPPermissions() {
   return new Promise((resolve, reject) => {
-    execSync(`chmod +x ${require('zxp-provider').osx}`);
+    if (process.platform !== 'win32') {
+      execSync(`chmod +x ${require('zxp-provider').osx}`);
+    }
     resolve();
   });
 }
@@ -115,7 +117,7 @@ function fixZXPPermissions() {
 function getOutputFilename() {
   const { NAME, VERSION } = cep.getSettings();
 
-  return `"${NAME}-${VERSION}.zxp"`;
+  return `${NAME}-${VERSION}.zxp`.replace(/ /g, '-');
 }
 
 function getOutputPath(fileName) {

--- a/packages/create-cep-extension-scripts/scripts/cep.js
+++ b/packages/create-cep-extension-scripts/scripts/cep.js
@@ -195,13 +195,21 @@ function writeExtensionTemplates(env, { port } = {}) {
 }
 
 function getExtenstionPath() {
-  return '/Library/Application Support/Adobe/CEP/extensions';
+  if (process.platform === 'win32') {
+    return 'C:\\Program Files (x86)\\Common Files\\Adobe\\CEP\\extensions'
+  } else {
+    return '/Library/Application Support/Adobe/CEP/extensions';
+  }
 }
 
 function getSymlinkExtensionPath() {
   const { BUNDLE_ID } = getSettings();
   const extensionPath = getExtenstionPath();
-  return path.join(process.env.HOME, extensionPath, BUNDLE_ID);
+  if (process.platform === 'win32') {
+    return path.join(extensionPath, BUNDLE_ID);
+  } else {
+    return path.join(process.env.HOME, extensionPath, BUNDLE_ID);
+  }
 }
 
 function symlinkExtension() {


### PR DESCRIPTION
Hi, 

I have added support for developing Adobe CEP in Windows environment

I made changes of the CEP extension filepath for Windows environment

Since windows can't refer filepath with the following format C:\Adobe\Projects\"My CEP-Extension-0.1", I propose replacing the spaces for output filename with '-' for simplicity.