### PR TITLE
Fix writeLn is not function issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Evaluates the specified code. Returns a Promise.
 ````javascript
 import { evalExtendscript } from 'cep-interface'
 
-evalExtendscript('writeLn("Hello Foo");') // writes "Hello Foo" to the info panel
+evalExtendscript('$.writeln("Hello Foo");') // writes "Hello Foo" to the info panel
 ````
 
 If you return a JSON string using [json2](https://github.com/douglascrockford/JSON-js) or similar from Extendscript, you can get the parsed result.

--- a/packages/create-cep-extension-scripts/template/extendscript/index.jsx
+++ b/packages/create-cep-extension-scripts/template/extendscript/index.jsx
@@ -1,3 +1,3 @@
 ﻿(function() {
-  writeLn('Hello World');
+  $.writeln('Hello World');
 })();

--- a/packages/create-cep-extension-scripts/template/src/index.js
+++ b/packages/create-cep-extension-scripts/template/src/index.js
@@ -6,7 +6,7 @@ import { inCEPEnvironment, evalExtendscript } from 'cep-interface';
 
 if (inCEPEnvironment()) {
   // write "Hello World!" to the info panel inside the host application
-  evalExtendscript('writeLn("Hello World!");');
+  evalExtendscript('$.writeln("Hello World!");');
 }
 
 ReactDOM.render(<App />, document.getElementById('root'));


### PR DESCRIPTION
Apparently, the example given cannot invoke Adobe JSX script, as writeLn is not the correct Adobe extendscript syntax, 

I have change it to prefix with '$.' and lowercase l