### PR TITLE
Fix symlink for windows dev enviroment

### DIFF
--- a/packages/create-cep-extension-scripts/scripts/cep.js
+++ b/packages/create-cep-extension-scripts/scripts/cep.js
@@ -216,7 +216,11 @@ function symlinkExtension() {
   fs.ensureDirSync(getExtenstionPath());
   let target = getSymlinkExtensionPath();
   fs.removeSync(target);
-  fs.symlinkSync(paths.appBuild, target);
+  if (process.platform === 'win32') {
+    fs.symlinkSync(paths.appBuild, target, 'junction');
+  } else {
+    fs.symlinkSync(paths.appBuild, target);
+  }
 }
 
 function printCEPExtensionLocation() {


### PR DESCRIPTION
For windows environment, require to pass in `junction` for creating symlink