### PR TITLE
Add CSS modules support

### DIFF
--- a/packages/create-cep-extension-scripts/config/webpack.config.dev.js
+++ b/packages/create-cep-extension-scripts/config/webpack.config.dev.js
@@ -191,6 +191,8 @@ module.exports = {
                 loader: require.resolve('css-loader'),
                 options: {
                   importLoaders: 1,
+                  modules: true,
+                  localIdentName: "[name]__[local]___[hash:base64:5]"  
                 },
               },
               {

--- a/packages/create-cep-extension-scripts/config/webpack.config.prod.js
+++ b/packages/create-cep-extension-scripts/config/webpack.config.prod.js
@@ -208,6 +208,7 @@ module.exports = {
                       loader: require.resolve('css-loader'),
                       options: {
                         importLoaders: 1,
+                        modules: true,
                         minimize: true,
                         sourceMap: shouldUseSourceMap,
                       },


### PR DESCRIPTION
Hi,

I've updated the webpack config to support [CSS modules](https://github.com/css-modules/css-modules). I'm not sure whether you want to merge it as a feature, as merging might cause the previous css rendering to fail.

With this implementation, it is required to wrap the css property with `:global` tag to declare the attribute as global scoped as mentioned [here](https://github.com/webpack-contrib/css-loader#scope)