### PR TITLE
Fix size parameter in `manifest.js`

### DIFF
--- a/packages/create-cep-extension-scripts/scripts/cep.js
+++ b/packages/create-cep-extension-scripts/scripts/cep.js
@@ -142,7 +142,15 @@ function openChromeRemoteDebugger() {
 }
 
 function writeExtensionTemplates(env, { port } = {}) {
-  const { NAME, VERSION, BUNDLE_ID, BUNDLE_VERSION, HOSTS } = getSettings();
+  const {
+    NAME,
+    VERSION,
+    BUNDLE_ID,
+    BUNDLE_VERSION,
+    HOSTS,
+    PANEL_WIDTH,
+    PANEL_HEIGHT,
+  } = getSettings();
 
   // make sure the CSXS folder exists
   if (!fs.existsSync(paths.appBuild)) fs.mkdirSync(paths.appBuild);

--- a/packages/create-cep-extension-scripts/scripts/templates/manifest.js
+++ b/packages/create-cep-extension-scripts/scripts/templates/manifest.js
@@ -53,8 +53,8 @@ module.exports = function({
           <Menu>${bundleName}</Menu>
           <Geometry>
             <Size>
-              <Height>${width}</Height>
-              <Width>${height}</Width>
+              <Height>${height}</Height>
+              <Width>${width}</Width>
             </Size>
           </Geometry>
         </UI>


### PR DESCRIPTION
- Swapped `height` & `width` parameter.
- Imported missing size variables