### PR TITLE
Issue #26:Fix 'Errors after calling npm run eject'

### DIFF
--- a/packages/create-cep-extension-scripts/config/paths.js
+++ b/packages/create-cep-extension-scripts/config/paths.js
@@ -51,6 +51,7 @@ function getServedPath(appPackageJson) {
 // config after eject: we're in ./config/
 module.exports = {
   dotenv: resolveApp('.env'),
+  appPath: resolveApp('.'),
   appBuild: resolveApp('build'),
   appPublic: resolveApp('public'),
   appHtml: resolveApp('public/index.html'),

--- a/packages/create-cep-extension-scripts/scripts/eject.js
+++ b/packages/create-cep-extension-scripts/scripts/eject.js
@@ -80,7 +80,7 @@ inquirer
       }
     }
 
-    const folders = ['config', 'config/jest', 'scripts'];
+    const folders = ['config', 'config/jest', 'scripts', 'scripts/templates'];
 
     // Make shallow array of files paths
     const files = folders.reduce((files, folder) => {


### PR DESCRIPTION
Summary:
npm [start | run build | run archive] does not work after npm run eject

Description:
module.exports in path.js does not include appPath, which is used in
getSettings() in cep.js to get the extension version number, after eject.
This update adds appPath after eject.

In addition, scripts/templates was left off the list of folders to copy
when ejecting, so templates for .debug, manifest.xml and index.html were
not available. This update also adds the folder to the list of folders
to copy on eject.

Testing Done:
create-cep-extension was run to verify the code changes did not affect
an unejected package.

npm run eject was run and it was verified that scripts/templates existed
and all the template files were properly copied.

npm start was run and failed due to yarn.lock existing in the project
root.

npm install was run manually and then npm start was run, which now
properly opened the extension in the browser and InDesign.

npm run build and npm run archive were run and verifed the results were
as expected.

Signed-off-by: Rob Johnson <rob.johnson@berkadia.com>
Reviewed-by: [reviewer-name] <reviewer-email>
Signed-off-by: [owner-name] <owner-email>

<!--
Thank you for sending the PR!
If you changed any code, there are just two more things to do:

* Provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
